### PR TITLE
fix: gracefully handle network errors

### DIFF
--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -3,9 +3,11 @@ import fs from 'fs'
 import { collectiveSlugFromUrl } from './transforms'
 import { report, reportAndThrowError } from './misc'
 
+const FETCH_TIMEOUT = 3000
+
 const fetchJson = async url => {
   try {
-    return (await global.fetch(`${url}.json`)).json()
+    return (await global.fetch(`${url}.json`, { timeout: FETCH_TIMEOUT })).json()
   } catch (e) {
     report(e)
     reportAndThrowError(`Could not fetch ${url}.json`)
@@ -31,7 +33,7 @@ export const fetchLogo = async logoUrl => {
   }
 
   try {
-    const res = (await global.fetch(logoUrl))
+    const res = (await global.fetch(logoUrl, { timeout: FETCH_TIMEOUT }))
     if (isLogoResponseWellFormatted(res)) {
       return res.text()
     }

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -6,7 +6,7 @@ export const reportAndThrowError = msg => {
 }
 
 export const report = message => {
-  consola.fatal({
+  consola.debug({
     message: String(message),
     tag: 'opencollective'
   })


### PR DESCRIPTION
It almost took me a full day to find out why `yarn install` is hanging and never finishes! openCollective has blocked Iranian IP addresses (probably amazon). BTW in case of network problems, install never finishes. I think 3 seconds should be enough to fetch each JSON if the network is normal. I also changed the report level to debug. So in normal cases, users are not annoyed by network errors.